### PR TITLE
Ability to disable SSL in splunk forwarders

### DIFF
--- a/_returners/splunk_nebula_return.py
+++ b/_returners/splunk_nebula_return.py
@@ -46,8 +46,10 @@ def returner(ret):
     logging.info("Options: %s" % json.dumps(opts))
     http_event_collector_key = opts['token']
     http_event_collector_host = opts['indexer']
+    hec_ssl = opts['http_event_server_ssl']
     # Set up the collector
-    hec = http_event_collector(http_event_collector_key, http_event_collector_host)
+    hec = http_event_collector(http_event_collector_key, http_event_collector_host, http_event_server_ssl=hec_ssl)
+
     # st = "salt:hubble:nova"
     data = ret['return']
     minion_id = ret['id']
@@ -83,6 +85,13 @@ def _get_options():
     except:
         return None
     splunk_opts = {"token": token, "indexer": indexer, "sourcetype": sourcetype, "index": index}
+
+    try:
+        hec_ssl = __salt__['config.get']('hubblestack:pulsar:returner:splunk:hec_ssl')
+    except:
+        hec_ssl = True
+    splunk_opts["http_event_server_ssl"]=hec_ssl
+    
     return splunk_opts
 
 

--- a/_returners/splunk_nebula_return.py
+++ b/_returners/splunk_nebula_return.py
@@ -86,12 +86,9 @@ def _get_options():
         return None
     splunk_opts = {"token": token, "indexer": indexer, "sourcetype": sourcetype, "index": index}
 
-    try:
-        hec_ssl = __salt__['config.get']('hubblestack:pulsar:returner:splunk:hec_ssl')
-    except:
-        hec_ssl = True
+    hec_ssl = __salt__['config.get']('hubblestack:nebula:returner:splunk:hec_ssl', True)
     splunk_opts["http_event_server_ssl"]=hec_ssl
-    
+
     return splunk_opts
 
 

--- a/_returners/splunk_nova_return.py
+++ b/_returners/splunk_nova_return.py
@@ -45,8 +45,9 @@ def returner(ret):
     logging.info("Options: %s" % json.dumps(opts))
     http_event_collector_key = opts['token']
     http_event_collector_host = opts['indexer']
+    hec_ssl = opts['http_event_server_ssl']
     # Set up the collector
-    hec = http_event_collector(http_event_collector_key, http_event_collector_host)
+    hec = http_event_collector(http_event_collector_key, http_event_collector_host, http_event_server_ssl=hec_ssl)
     # st = "salt:hubble:nova"
     data = ret['return']
     minion_id = ret['id']
@@ -144,6 +145,10 @@ def _get_options():
     except:
         return None
     splunk_opts = {"token": token, "indexer": indexer, "sourcetype": sourcetype, "index": index}
+
+    hec_ssl = __salt__['config.get']('hubblestack:nova:returner:splunk:hec_ssl', True)
+    splunk_opts["http_event_server_ssl"]=hec_ssl
+
     return splunk_opts
 
 

--- a/_returners/splunk_pulsar_return.py
+++ b/_returners/splunk_pulsar_return.py
@@ -48,8 +48,9 @@ def returner(ret):
     logging.info("Options: %s" % json.dumps(opts))
     http_event_collector_key = opts['token']
     http_event_collector_host = opts['indexer']
+    hec_ssl = opts['http_event_server_ssl']
     # Set up the collector
-    hec = http_event_collector(http_event_collector_key, http_event_collector_host)
+    hec = http_event_collector(http_event_collector_key, http_event_collector_host, http_event_server_ssl=hec_ssl)
     # Check whether or not data is batched:
     if isinstance(ret, dict):  # Batching is disabled
         data = [ret]
@@ -142,6 +143,13 @@ def _get_options():
     except:
         return None
     splunk_opts = {"token": token, "indexer": indexer, "sourcetype": sourcetype, "index": index}
+
+    try:
+        hec_ssl = __salt__['config.get']('hubblestack:pulsar:returner:splunk:hec_ssl')
+    except:
+        hec_ssl = True
+    splunk_opts["http_event_server_ssl"]=hec_ssl
+
     return splunk_opts
 
 

--- a/_returners/splunk_pulsar_return.py
+++ b/_returners/splunk_pulsar_return.py
@@ -144,10 +144,7 @@ def _get_options():
         return None
     splunk_opts = {"token": token, "indexer": indexer, "sourcetype": sourcetype, "index": index}
 
-    try:
-        hec_ssl = __salt__['config.get']('hubblestack:pulsar:returner:splunk:hec_ssl')
-    except:
-        hec_ssl = True
+    hec_ssl = __salt__['config.get']('hubblestack:pulsar:returner:splunk:hec_ssl', True)
     splunk_opts["http_event_server_ssl"]=hec_ssl
 
     return splunk_opts


### PR DESCRIPTION
Thanks @scottjpack for the original code, CC @mew1033 

An updated pillar would look like this for Nova:

``` yaml
nova:
  returner:
    splunk:
      token: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
      indexer: splunk-indexer.domain.tld
      sourcetype: hubble_audit
      index: hubble
      hec_ssl: False
```

Would you like me to update the pillar.example file with the new additions?
