### PR TITLE
Catch all requests exceptions when trying to get aws metadata

### DIFF
--- a/_returners/splunk_nebula_return.py
+++ b/_returners/splunk_nebula_return.py
@@ -84,7 +84,7 @@ def returner(ret):
                                        timeout=1).text
         aws_account_id = requests.get('http://169.254.169.254/latest/dynamic/instance-identity/document',
                                       timeout=1).json().get('accountId', 'unknown')
-    except (requests.exceptions.ConnectTimeout, ValueError):
+    except (requests.exceptions.RequestException, ValueError):
         # Not on an AWS box
         pass
 

--- a/_returners/splunk_nova_return.py
+++ b/_returners/splunk_nova_return.py
@@ -83,7 +83,7 @@ def returner(ret):
                                        timeout=1).text
         aws_account_id = requests.get('http://169.254.169.254/latest/dynamic/instance-identity/document',
                                       timeout=1).json().get('accountId', 'unknown')
-    except (requests.exceptions.ConnectTimeout, ValueError):
+    except (requests.exceptions.RequestException, ValueError):
         # Not on an AWS box
         pass
 

--- a/_returners/splunk_pulsar_return.py
+++ b/_returners/splunk_pulsar_return.py
@@ -89,7 +89,7 @@ def returner(ret):
                                        timeout=1).text
         aws_account_id = requests.get('http://169.254.169.254/latest/dynamic/instance-identity/document',
                                       timeout=1).json().get('accountId', 'unknown')
-    except (requests.exceptions.ConnectTimeout, ValueError):
+    except (requests.exceptions.RequestException, ValueError):
         # Not on an AWS box
         pass
 


### PR DESCRIPTION
Reported by @jettero. Thanks!

@basepi Should we just catch every error that requests could throw? I guess we could also just catch `requests.exceptions.ConnectTimeout` and `requests.exceptions.ConnectionError`. What say you?